### PR TITLE
Fix absolute links in READMEs

### DIFF
--- a/lecture_4/src/higher_order_components/README.md
+++ b/lecture_4/src/higher_order_components/README.md
@@ -18,7 +18,7 @@ functions as a result.
 enhanced React components. This is a standard pattern which is present in most
 contexts that deal with composable objects.
 
-Check out [HigherOrderComponentsExample](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/higher_order_components/HigherOrderComponentsExample.js).
+Check out [HigherOrderComponentsExample](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/higher_order_components/HigherOrderComponentsExample.js).
 
 ## Higher-Order Components vs Hooks
 

--- a/lecture_4/src/redux_basics/README.md
+++ b/lecture_4/src/redux_basics/README.md
@@ -28,7 +28,7 @@ React-Redux significantly changes how container components are defined.
 
 ### Actions
 
-This example application has [3 actions](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_basics/actions/index.js) that capture all
+This example application has [3 actions](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_basics/actions/index.js) that capture all
 user interactions.
 
 * `COMMENT_SUBMITTED`
@@ -37,24 +37,24 @@ user interactions.
 
 ### Reducers
 
-A [single reducer](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_basics/reducers/index.js) has been defined to handle all actions.
+A [single reducer](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_basics/reducers/index.js) has been defined to handle all actions.
 New comments are added to comments already in the state. `AUTHOR_SET`,
 `TEXT_SET` actions are handled trivially.
 
 ### Application setup
 
-[Application root](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_basics/ReduxBasics.js) has been changed to create a Redux store.
+[Application root](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_basics/ReduxBasics.js) has been changed to create a Redux store.
 This store is passed to child components using the `Provider` components which
 gives all children components access to the store.
 
 ### Container components
 
-[`App`](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_basics/containers/App.js) container has been changed significantly. It
+[`App`](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_basics/containers/App.js) container has been changed significantly. It
 defines a simple presentational component that contains all the other
 components. The presentational component receives all its props from a
 auto-generated wrapper component that is generated using _react-redux_.
 
-Read the comments in [`App`](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_basics/containers/App.js) and react-redux documentation
+Read the comments in [`App`](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_basics/containers/App.js) and react-redux documentation
 for more information.
 
 ### Tests
@@ -67,9 +67,9 @@ _selector_ functions and test those in isolation.
 Note that it is much nicer to test reducer functions than it is to test
 application logic through React components.
 
-[`CommentForm`](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_basics/components/CommentForm.js) is changed to not have any internal
+[`CommentForm`](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_basics/components/CommentForm.js) is changed to not have any internal
 state. This might or might not be desirable, depends on the use case. Check
 `CommentForm` for more information.
 
-Redux dev tools [are integrated with store](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_basics/ReduxBasics.js#L15) if
+Redux dev tools [are integrated with store](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_basics/ReduxBasics.js#L15) if
 `devToolsExtension` is present on window.

--- a/lecture_4/src/redux_combine_reducers/README.md
+++ b/lecture_4/src/redux_combine_reducers/README.md
@@ -16,16 +16,16 @@ Open _Redux combine reducers example_ subpage.
 ## New functionality
 
 
-The application now has a [`Filter`](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_combine_reducers/components/Filter.js) to filter comments
+The application now has a [`Filter`](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_combine_reducers/components/Filter.js) to filter comments
 by text or author.
 
-[`CommentForm`](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_combine_reducers/components/CommentForm.js) has been reverted to hold the
+[`CommentForm`](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_combine_reducers/components/CommentForm.js) has been reverted to hold the
 input state in the component as it is not important for the rest of the
 application until a comment has been submitted.
 
 ## Actions
 
-This example application has [2 actions](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_combine_reducers/actions/index.js) that capture all
+This example application has [2 actions](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_combine_reducers/actions/index.js) that capture all
 user interactions.
 
 * `COMMENT_SUBMITTED`
@@ -33,13 +33,13 @@ user interactions.
 
 ### Reducers
 
-Two reducers are combined in [`./reducers/index.js`](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_combine_reducers/reducers/index.js) under
+Two reducers are combined in [`./reducers/index.js`](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_combine_reducers/reducers/index.js) under
 different namespaces using `combineReducers` from `redux`.
 
-* [`CommentListReducer`](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_combine_reducers/reducers/CommentListReducer.js) handles submission
+* [`CommentListReducer`](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_combine_reducers/reducers/CommentListReducer.js) handles submission
   of new comments and provides a selector function to apply a filter to a list
   of comments.
-* [`CommentFilterReducer`](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_combine_reducers/reducers/CommentFilterReducer.js) simply stores
+* [`CommentFilterReducer`](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_combine_reducers/reducers/CommentFilterReducer.js) simply stores
   the current filter value.
 
 Note that both the reducers are fully tested as they contain all the
@@ -50,9 +50,9 @@ application logic.
 Multiple containers are used to avoid collecting all properties and callbacks
 in the root component. 
 
-* [`CommentFormContainer`](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_combine_reducers/containers/CommentFormContainer.js) wraps `CommentForm`
-* [`CommentListContainer`](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_combine_reducers/containers/CommentListContainer.js) wraps `CommentList`
-* [`FilterContainer`](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_combine_reducers/containers/FilterContainer.js) wraps `Filter`
+* [`CommentFormContainer`](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_combine_reducers/containers/CommentFormContainer.js) wraps `CommentForm`
+* [`CommentListContainer`](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_combine_reducers/containers/CommentListContainer.js) wraps `CommentList`
+* [`FilterContainer`](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_combine_reducers/containers/FilterContainer.js) wraps `Filter`
 
 Note that container components are not reusable as they are tied to a specific
 part of application state.

--- a/lecture_4/src/redux_introduction/README.md
+++ b/lecture_4/src/redux_introduction/README.md
@@ -21,7 +21,7 @@ All application state is captured in a single JavaScript object. That object is
 stored in Redux store. The only way to modify that object (and therefore
 application state) is to dispatch actions. 
 
-[Example store](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_introduction/ReduxExample.js#L20)
+[Example store](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_introduction/ReduxExample.js#L20)
 
 ### Actions
 
@@ -32,7 +32,7 @@ change the application state.
 
 [Flux standard format](https://github.com/acdlite/flux-standard-action) is used for actions.
 
-[Example actions](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_introduction/ReduxExample.js#L26)
+[Example actions](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_introduction/ReduxExample.js#L26)
 
 ### Reducers
 
@@ -44,6 +44,6 @@ A reducer usually switches over the action type to handle different types of
 actions differently. If a reducer encounters an unknown action, it must return
 the state as it is.
 
-[Example reducer](https://github.com/urmastalimaa/interactive-frontend-development/lecture_4/src/redux_introduction/ReduxExample.js#L5)
+[Example reducer](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_4/src/redux_introduction/ReduxExample.js#L5)
 
 [Learn more about redux](https://redux.js.org)

--- a/lecture_5/src/async_process_basics/README.md
+++ b/lecture_5/src/async_process_basics/README.md
@@ -45,13 +45,13 @@ needs to be capture by our application.
 ### Components
 
 Comments can now be fetched from a server. This request is asynchronous.
-[CommentList](https://github.com/urmastalimaa/interactive-frontend-development/lecture_5/src/components/CommentList.js#L20-36)
+[CommentList](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_5/src/components/CommentList.js#L20-36)
 has been changed to accomodate three different stages of the request:
 in-flight, success and error.
 
 Submitting Comments is also asynchronous. Every comment itself can also be
 in-flight.
-[Comment](https://github.com/urmastalimaa/interactive-frontend-development/lecture_5/src/components/Comment.js)
+[Comment](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_5/src/components/Comment.js)
 has been changed accordingly.
 
 ### Containers
@@ -61,18 +61,18 @@ components.
 
 ### Reducers
 
-[CommentListReducer](https://github.com/urmastalimaa/interactive-frontend-development/lecture_5/src/reducers/CommentListReducer.js)
+[CommentListReducer](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_5/src/reducers/CommentListReducer.js)
 has been changed to handle 6 actions. 3 different possible results for both
 fetching and posting comments.
 
 ### Actions
 
 There are 6 _simple_, synchronous action creators in the [actions
-file](https://github.com/urmastalimaa/interactive-frontend-development/lecture_5/src/actions/index.js)
+file](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_5/src/actions/index.js)
 representing the different results of the two asynchronous processes. There are
 two asynchronous action creators for posting a comment and fetching all
 comments in
-[CommentServerActions](https://github.com/urmastalimaa/interactive-frontend-development/lecture_5/src/actions/CommentServerActions.js).
+[CommentServerActions](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_5/src/actions/CommentServerActions.js).
 The asynchronous action creators make use of a [`fetch`
 API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) which supports
 making requests to remote servers.

--- a/lecture_5/src/async_process_with_middleware/README.md
+++ b/lecture_5/src/async_process_with_middleware/README.md
@@ -30,16 +30,16 @@ clarity and explicity of Redux.
 ### CommentServerMiddleware
 
 In this example
-[CommentListContainer](https://github.com/urmastalimaa/interactive-frontend-development/lecture_5/src/containers/CommentListContainer.js)
+[CommentListContainer](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_5/src/containers/CommentListContainer.js)
 and
-[CommentFormContainer](https://github.com/urmastalimaa/interactive-frontend-development/lecture_5/src/containers/CommentFormContainer.js)
+[CommentFormContainer](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_5/src/containers/CommentFormContainer.js)
 have been changed to simply express the desire to perform an action, the
 containers no longer directly call functions that make asynchronous calls. This
 means that the React/Redux containers do not call functions tied to any
 particular Server interface.
 
 Instead
-[CommentServerMiddleware](https://github.com/urmastalimaa/interactive-frontend-development/lecture_5/src/middlewares/CommentServerMiddleware.js)
+[CommentServerMiddleware](https://github.com/urmastalimaa/interactive-frontend-development/blob/master/lecture_5/src/middlewares/CommentServerMiddleware.js)
 has been added that listens for actions that should fire requests to the
 server. It then initiates the request and dispatches success/failure actions
 accordingly.


### PR DESCRIPTION
The links were broken by converting them to be absolute links to files
in master branch.